### PR TITLE
flutter pub get fails

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -9,8 +9,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  flutter_localizations:
-    sdk: flutter
 
   intl: ^0.16.1
   


### PR DESCRIPTION
`flutter pub get` fails with error
>pub get failed (1; So, because example depends on date_time_picker ^1.1.0 which
depends on intl ^0.16.1, version solving failed.)