### PR TITLE
Added initialDate and initialTime fields for when initialValue is empty and lastDate is before now

### DIFF
--- a/lib/date_time_picker.dart
+++ b/lib/date_time_picker.dart
@@ -138,6 +138,8 @@ class DateTimePicker extends FormField<String> {
     this.controller,
     this.firstDate,
     this.lastDate,
+    this.initialDate,
+    this.initialTime,
     this.dateMask,
     this.icon,
     this.dateLabelText,
@@ -384,6 +386,12 @@ class DateTimePicker extends FormField<String> {
   /// The latest allowable [DateTime] that the user can select.
   final DateTime lastDate;
 
+  /// The initial date to be used for the date picker if initialValue is null or empty
+  final DateTime initialDate;
+
+  /// The initial time to be used for the time picker if initialValue is null or empty
+  final TimeOfDay initialTime;
+
   /// For forms that match one of our predefined skeletons, we look up the
   /// corresponding pattern in [locale] (or in the default locale if none is
   /// specified) and use the resulting full format string. This is the
@@ -533,6 +541,9 @@ class _DateTimePickerState extends FormFieldState<String> {
   @override
   void initState() {
     super.initState();
+
+    _dDate = widget.initialDate ?? DateTime.now();
+    _tTime = widget.initialTime ?? TimeOfDay.now();
 
     if (widget.controller == null) {
       _stateController = TextEditingController(text: widget.initialValue);


### PR DESCRIPTION
When I set the `initialValue` of the field to be the empty string, and `lastDate` in the past, when I try to open the date picker, I get an exception because date time picker is opened with `DateTime.now()` as a default, which breaks the assertion that `initialDate` must be before `lastDate`. So I added `initialDate` and `initialTime` fields for that purpose, so that we can keep initial value empty and still work with date time picker dialog properly.

You can test this with [the project here](https://github.com/sarbogast/date_time_picker_test).
If you run it as is, using the current version of date_time_picker, and you click the field, you will get an exception.
But if you comment in [lines 35-37](https://github.com/sarbogast/date_time_picker_test/blob/master/pubspec.yaml#L35) in `pubspec.yaml`, and [lines 53-57](https://github.com/sarbogast/date_time_picker_test/blob/master/lib/main.dart#L53) in `main.dart`, and get dependencies again to use my fork instead of the current version, now the exception is gone.

This is the easiest solution I could find, and I didn't test the time element because I don't use it right now. So I just did the same thing for time as for date, hoping that it would work. 