### PR TITLE
Removed unneeded beta version tag

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.17.0-nullsafety.2
+  intl: ^0.17.0
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
intl library is no longer in beta with the release of Flutter 2. This simple change corrects blocking issue for #25 and #26 