### PR TITLE
fix inconsistent time format

### DIFF
--- a/lib/date_time_picker.dart
+++ b/lib/date_time_picker.dart
@@ -850,14 +850,14 @@ class _DateTimePickerState extends FormFieldState<String> {
 
       _timeLabelController.text = _sTime + _sPeriod;
       final lsOldValue = _sValue;
-      _sValue = _sTime;
+      _sValue = _sTime + _sPeriod;
 
       if (widget.type == DateTimePickerType.dateTimeSeparate && _sDate != '') {
-        _sValue = '$_sDate $_sTime';
+        _sValue = '$_sDate $_sTime $_sPeriod';
       }
 
       _sValue = _sValue.trim();
-      _effectiveController?.text = _sValue + _sPeriod;
+      _effectiveController?.text = _sValue;
 
       if (_sValue != lsOldValue) {
         onChangedHandler(_sValue);

--- a/lib/date_time_picker.dart
+++ b/lib/date_time_picker.dart
@@ -4,6 +4,8 @@
 
 library date_time_picker;
 
+import 'dart:core';
+
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:intl/intl.dart';
@@ -582,18 +584,51 @@ class _DateTimePickerState extends FormFieldState<String> {
               DateFormat(lsMask, languageCode).format(_dDate);
         }
       } else {
-        final llTime = lsValue.split(':');
-        _tTime =
-            TimeOfDay(hour: int.parse(llTime[0]), minute: int.parse(llTime[1]));
+        final llTime = lsValue.split(RegExp(r'[:, \s]'));
+        if (llTime.length == 3) {
+          // if case when string in hh:mm a format
+          _tTime = _getTimeOfDay12HrsFormat(
+            llTime[0],
+            llTime[1],
+            llTime[2],
+          );
+        } else {
+          // when format is HH:mm
+          _tTime = TimeOfDay(
+            hour: int.parse(llTime[0]),
+            minute: int.parse(llTime[1]),
+          );
+        }
+
         _sTime = lsValue;
 
         if (!widget.use24HourFormat) {
-          _sPeriod = _tTime.period.index == 0 ? ' AM' : ' PM';
+          set12HourTimeValues(_tTime);
         }
+
+        _effectiveController?.text = _sTime + _sPeriod;
 
         _timeLabelController.text = _sTime + _sPeriod;
       }
     }
+  }
+
+  TimeOfDay _getTimeOfDay12HrsFormat(
+    String hourStr,
+    String minuteStr,
+    String periodStr,
+  ) {
+    var hour = int.parse(hourStr);
+    if (periodStr == 'PM') {
+      hour = hour == 12 ? 12 : hour + 12;
+    }
+    if (periodStr == 'AM' && hour == 12) {
+      hour = 0;
+    }
+
+    final minute = int.parse(minuteStr);
+
+    return TimeOfDay(hour: hour, minute: minute);
   }
 
   @override
@@ -661,10 +696,22 @@ class _DateTimePickerState extends FormFieldState<String> {
                 DateFormat(lsMask, languageCode).format(_dDate);
           }
         } else {
-          final llTime = lsValue.split(':');
-          _tTime = TimeOfDay(
-              hour: int.parse(llTime[0]), minute: int.parse(llTime[1]));
-          _sTime = lsValue;
+          final llTime = lsValue.split(RegExp(r'[:, \s]'));
+          if (llTime.length == 3) {
+            // in case when string in hh:mm a format
+            _tTime = _getTimeOfDay12HrsFormat(
+              llTime[0],
+              llTime[1],
+              llTime[2],
+            );
+          } else {
+            // when format is HH:mm
+            _tTime = TimeOfDay(
+              hour: int.parse(llTime[0]),
+              minute: int.parse(llTime[1]),
+            );
+          }
+          _sTime = '${llTime[0]}:${llTime[1]}';
           _timeLabelController.text = _sTime + _sPeriod;
         }
       }
@@ -801,7 +848,7 @@ class _DateTimePickerState extends FormFieldState<String> {
 
       _tTime = ltTimePicked;
 
-      _timeLabelController.text = _sTime;
+      _timeLabelController.text = _sTime + _sPeriod;
       final lsOldValue = _sValue;
       _sValue = _sTime;
 
@@ -810,7 +857,7 @@ class _DateTimePickerState extends FormFieldState<String> {
       }
 
       _sValue = _sValue.trim();
-      _effectiveController?.text = _sValue;
+      _effectiveController?.text = _sValue + _sPeriod;
 
       if (_sValue != lsOldValue) {
         onChangedHandler(_sValue);


### PR DESCRIPTION
This PR fixes inconsistent time formats when use `DateTimePickerType.time` with 12 hour format. In current version, inputs will show time in format `HH;mm a` until you edit it manually.
So, when you use widget like this:

```
late TextEditingController _timeController;
...
final now = DateTime(2021, 07, 15, 13, 0, 0);
final hours = DateFormat('HH').format(now);
final minutes = DateFormat('mm').format(now);
_timeController = TextEditingController(text: '$hours:$minutes');
...
DateTimePicker(
    type: DateTimePickerType.time,
    controller: _timeController,
    firstDate: DateTime(2000),
    lastDate: DateTime(2100),
    use24HourFormat: false,
    locale: Locale('en', 'US'),
    decoration: InputDecoration(
        border: OutlineInputBorder(
            borderRadius: BorderRadius.circular(4),
            borderSide: BorderSide(
                width: 2.0,
                color: Colors.black,
            ),
        ),
        floatingLabelBehavior: FloatingLabelBehavior.always,
        labelText: 'Time',
        suffixIcon: Icon(Icons.access_time),
    ),
),
```
It will be shown like this when screen loaded
![image](https://user-images.githubusercontent.com/30033017/125756484-6c01cb05-c8e0-48f9-83e5-ba8dcc1950b6.png)
when you pick another time and click 'OK' label will be shown like this:
![image](https://user-images.githubusercontent.com/30033017/125756628-b1bb49a8-1323-400b-b22e-4b46ce0b5fcf.png)
Also, when you use controller with current plugin version - it's text may be different based on - did you select another time or not. That's why I call `_effectiveController?.text = _sTime + _sPeriod;` in `initValues()`
Also, it will throw an exception when you try to pass a controller like this:
```
final now = DateTime(2021, 07, 15, 13, 0, 0);
final hours = DateFormat('hh').format(now);
final minutes = DateFormat('mm').format(now);
_timeController = TextEditingController(text: '$hours:$minutes PM');
```
this PR fixes it as well