### PR TITLE
fix: Clear date when controller is reset

### DIFF
--- a/lib/date_time_picker.dart
+++ b/lib/date_time_picker.dart
@@ -669,11 +669,19 @@ class _DateTimePickerState extends FormFieldState<String> {
         }
       }
     } else {
-      _dateLabelController.clear();
-      _timeLabelController.clear();
-
-      initValues();
+      clearSelection();
     }
+  }
+
+  // Clear the date/time selection.
+  void clearSelection() {
+    _dateLabelController.clear();
+    _timeLabelController.clear();
+    _effectiveController?.clear();
+
+    _sDate = "";
+    _sTime = "";
+    initValues();
   }
 
   @override


### PR DESCRIPTION
Closes #35 

The date/time field can be cleared by clearing its controller and rebuilding the DateTimePicker widget.

What was missing was to set `_sDate` to `""` so that it doesn't just keep the last selected date.