### PR TITLE
Change intl to 0.18.

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  intl: ^0.17.0
+  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
Please update intl 0.17 to 0.18 , to support flutter 3.10.5 sdk, because flutter sdk depend intl 0.18, but the date time pikcer need 0.17 So can not resolve the version conflict! Here is the commit.